### PR TITLE
Rename tool to Failed Job Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ public function tools()
 
 ## Usage
 
-Click on the "Failed Jobs Log" menu item in your Nova app to see the tool provided by this package.
+Click on the "Failed Job Manager" menu item in your Nova app to see the tool provided by this package.
 
 ## Contributing
 

--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -1,6 +1,6 @@
 <router-link tag="h3" :to="{name: 'nova-failed-jobs'}" class="cursor-pointer flex items-center font-normal dim text-white mb-6 text-base no-underline">
     <svg class="sidebar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="#B3C1D1" d="M3 1h4c1.1045695 0 2 .8954305 2 2v4c0 1.1045695-.8954305 2-2 2H3c-1.1045695 0-2-.8954305-2-2V3c0-1.1045695.8954305-2 2-2zm0 2v4h4V3H3zm10-2h4c1.1045695 0 2 .8954305 2 2v4c0 1.1045695-.8954305 2-2 2h-4c-1.1045695 0-2-.8954305-2-2V3c0-1.1045695.8954305-2 2-2zm0 2v4h4V3h-4zM3 11h4c1.1045695 0 2 .8954305 2 2v4c0 1.1045695-.8954305 2-2 2H3c-1.1045695 0-2-.8954305-2-2v-4c0-1.1045695.8954305-2 2-2zm0 2v4h4v-4H3zm10-2h4c1.1045695 0 2 .8954305 2 2v4c0 1.1045695-.8954305 2-2 2h-4c-1.1045695 0-2-.8954305-2-2v-4c0-1.1045695.8954305-2 2-2zm0 2v4h4v-4h-4z"/></svg>
     <span class="sidebar-label">
-        Failed Jobs Log
+        Failed Job Manager
     </span>
 </router-link>


### PR DESCRIPTION
This resolves #8 to make the naming throughout the tool consistent.